### PR TITLE
Updating the makecode script refrence in Readme

### DIFF
--- a/Wireless-CSV/README.md
+++ b/Wireless-CSV/README.md
@@ -5,7 +5,7 @@ Once your CSV file is created, it is pretty simple to open it up with Microsoft 
 The process involves 2 parts, the script which runs on both the micro:bits and the Python script running on the logging computer which reads the serial data from the micro:bit over USB.    
 
 ## Micro:bit script
-The script that runs on both of the BBC micro:bits is written using the [Microsoft PXT platform](https://pxt.io/). The code in Typescript is included, or you can easily just [fork the script](https://m.pxt.io/vxdmdu).   
+The script that runs on both of the BBC micro:bits is written using the [Microsoft PXT platform](https://pxt.io/). The code in Typescript is included, or you can easily just [fork the script](https://makecode.microbit.org/_UK9M5hWfpg70).   
 If you want to log something different other than the accelerometer values, simply change the input block in the ```send value``` block.
     
 ## Python logging script   


### PR DESCRIPTION
This change moves from the shared script to new domain from the older domain.
https://m.pxt.io/vxdmdu to https://makecode.microbit.org/_UK9M5hWfpg70
Script content is exactly same. 

I am from MakeCode team and we are bulk moving the legacy scripts to new domain.